### PR TITLE
Update class-edit-form.php

### DIFF
--- a/core/classes/class-edit-form.php
+++ b/core/classes/class-edit-form.php
@@ -714,7 +714,7 @@ class BPSimpleBlogPostEditForm {
 
 			foreach ( $keys as $k ) {
 
-				if ( in_array( $categories[ $k ]->term_id, $args['selected_cats'] ) ) {
+				if ( is_array($args['selected_cats'] ) && in_array( $categories[ $k ]->term_id, $args['selected_cats'] ) ) {
 					$checked_categories[] = $categories[ $k ];
 					unset( $categories[ $k ] );
 				}


### PR DESCRIPTION
fix php Warning when allowed only 1 write category in Wordpress